### PR TITLE
Uninitialized flags can lead to skipping output events.

### DIFF
--- a/driver/cl-alsaseq.lisp
+++ b/driver/cl-alsaseq.lisp
@@ -104,11 +104,12 @@
     (setf (mem-ref client :uchar) *client )))
 
 (defmacro with-midi-event ((var data type
-                                &key (queue snd_seq_queue_direct))
+                                &key (queue snd_seq_queue_direct) (flags 0))
                            &body body)
   `(let ((,var (convert-to-foreign (list
                                     'type ,type
                                     'queue ,queue
+                                    'flags ,flags
                                     )
                                    '(:struct snd_seq_event_t))))
      (with-foreign-slots (((:pointer data))


### PR DESCRIPTION
When flags are not set to zero (fixed length MIDI event), its value
depends on memory content. Sometimes an event is not sent, snd_seq_event_output
returns -22 (EINVAL), due to flags appears to be set to variable length,
and the calculated length is incorrect.

The problem is reproduced with SBCL with the scenario like this:
```
(defparameter *seq (cl-alsaseq:open-seq "CLtest"))
(defparameter *seq* (cffi:mem-ref *seq :pointer))
(defparameter *port* (cl-alsaseq:open-port "out" *seq* :duplex))
(defparameter *sleep* 0.05)

(loop
  (cl-alsaseq:send-note 127 127 0 :SND_SEQ_EVENT_NOTEON *seq* *port*)
  (sleep *sleep*)
  (cl-alsaseq:send-note 0 127 0 :SND_SEQ_EVENT_NOTEON *seq* *port*))
```

On the receiving end I see substantial amount of events are missing. Also, if I modify (send-midi) call to return the code from snd_seq_event_output, I see some calls returning -22 randomly.